### PR TITLE
Feature/commit counter

### DIFF
--- a/githubmotivator/settings.py
+++ b/githubmotivator/settings.py
@@ -139,7 +139,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Other settings
 
-INTERNAL_IPS = ["127.0.0.1"]
+INTERNAL_IPS = ["127.0.0.1", "localhost"]
 
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
@@ -153,3 +153,5 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_HOST_USER = env.str("EMAIL_USER")
 EMAIL_HOST_PASSWORD = env.str("EMAIL_PASSWORD")
+
+DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG}

--- a/githubmotivator/settings.py
+++ b/githubmotivator/settings.py
@@ -32,7 +32,7 @@ SECRET_KEY = env.str("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["ffc1-86-83-204-47.eu.ngrok.io", "localhost"]
+ALLOWED_HOSTS = ["localhost"]
 
 
 # Application definition

--- a/githubmotivator/settings.py
+++ b/githubmotivator/settings.py
@@ -32,7 +32,7 @@ SECRET_KEY = env.str("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["ffc1-86-83-204-47.eu.ngrok.io", "localhost"]
 
 
 # Application definition

--- a/githubmotivator/urls.py
+++ b/githubmotivator/urls.py
@@ -1,49 +1,51 @@
-"""githubmotivator URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
+"""githubmotivator URL Configuration"""
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from django.urls import path, include
+from django.urls import include, path
 from users import views as users_views
 
-
 urlpatterns = [
-    path('__debug__/', include('debug_toolbar.urls')),
-    path('admin/', admin.site.urls),
-    path('register/', users_views.register, name='users-register'),
-    path('login/', auth_views.LoginView.as_view(template_name='users/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout'),
-    path('profile/', users_views.profile, name='users-profile'),
-    path('password-reset/',
-         auth_views.PasswordResetView.as_view(
-             template_name='users/password_reset.html'),
-         name='password_reset'),
-    path('password-reset/done/',
-         auth_views.PasswordResetDoneView.as_view(
-             template_name='users/password_reset_done.html'),
-         name='password_reset_done'),
-    path('password-reset-confirm/<uidb64>/<token>/',
-         auth_views.PasswordResetConfirmView.as_view(
-             template_name='users/password_reset_confirm.html'),
-         name='password_reset_confirm'),
-    path('password-reset-complete/',
-         auth_views.PasswordResetCompleteView.as_view(
-             template_name='users/password_reset_complete.html'),
-         name='password_reset_complete'),
-    path('', include('motivator.urls')),
+    path("__debug__/", include("debug_toolbar.urls")),
+    path("admin/", admin.site.urls),
+    path("register/", users_views.register, name="users-register"),
+    path(
+        "login/",
+        auth_views.LoginView.as_view(template_name="users/login.html"),
+        name="login",
+    ),
+    path(
+        "logout/",
+        auth_views.LogoutView.as_view(template_name="users/logout.html"),
+        name="logout",
+    ),
+    path("profile/", users_views.profile, name="users-profile"),
+    path(
+        "password-reset/",
+        auth_views.PasswordResetView.as_view(
+            template_name="users/password_reset.html"
+        ),
+        name="password_reset",
+    ),
+    path(
+        "password-reset/done/",
+        auth_views.PasswordResetDoneView.as_view(
+            template_name="users/password_reset_done.html"
+        ),
+        name="password_reset_done",
+    ),
+    path(
+        "password-reset-confirm/<uidb64>/<token>/",
+        auth_views.PasswordResetConfirmView.as_view(
+            template_name="users/password_reset_confirm.html"
+        ),
+        name="password_reset_confirm",
+    ),
+    path(
+        "password-reset-complete/",
+        auth_views.PasswordResetCompleteView.as_view(
+            template_name="users/password_reset_complete.html"
+        ),
+        name="password_reset_complete",
+    ),
+    path("", include("motivator.urls")),
 ]
-# Password reset probably not working due to boolean values not working in djongo correctly...
-# Query for password reset checks if user is_active, which returns a FAILED SQL
-# https://github.com/doableware/djongo/issues/465

--- a/motivator/forms.py
+++ b/motivator/forms.py
@@ -7,15 +7,19 @@ from .utils import get_response_from_url
 
 
 class GoalForm(ModelForm):
+    """The Form for adding new Goals"""
+
     class Meta:
         model = Goal
         fields = ["repo", "commit_goal", "amount", "start_date", "end_date"]
 
     def __init__(self, github_username, *args, **kwargs):
+        """Initialize the form and add the github_username"""
         self.github_username = github_username
         super().__init__(*args, **kwargs)
 
     def validate_dates(self, start_date, end_date):
+        """Validate the start en end dates"""
         if start_date and end_date:
             if end_date < start_date:
                 raise ValidationError(
@@ -38,6 +42,7 @@ class GoalForm(ModelForm):
                 )
 
     def validate_repo(self, github_username, repo):
+        """Validate the Github repo url"""
         url = f"https://github.com/{github_username}/{repo}"
         if "message" in get_response_from_url(url):
             raise ValidationError(
@@ -45,6 +50,7 @@ class GoalForm(ModelForm):
             )
 
     def clean(self):
+        """Clean and validate the data"""
         cleaned_data = super().clean()
 
         start_date = cleaned_data.get("start_date")

--- a/motivator/forms.py
+++ b/motivator/forms.py
@@ -2,8 +2,8 @@ from django.core.exceptions import ValidationError
 from django.forms import ModelForm
 from django.utils import timezone
 
-from .models import Goal
-from .utils import get_response_from_url
+from motivator.models import Goal
+from motivator.utils import get_response_from_url
 
 
 class GoalForm(ModelForm):
@@ -45,9 +45,7 @@ class GoalForm(ModelForm):
         """Validate the Github repo url"""
         url = f"https://github.com/{github_username}/{repo}"
         if "message" in get_response_from_url(url):
-            raise ValidationError(
-                {"repo": "This Github repository could not be found."}
-            )
+            raise ValidationError({"repo": "This Github repository could not be found."})
 
     def clean(self):
         """Clean and validate the data"""

--- a/motivator/forms.py
+++ b/motivator/forms.py
@@ -3,6 +3,7 @@ from django.forms import ModelForm
 from django.utils import timezone
 
 from .models import Goal
+from .utils import get_response_from_url
 
 
 class GoalForm(ModelForm):
@@ -10,12 +11,11 @@ class GoalForm(ModelForm):
         model = Goal
         fields = ["repo", "commit_goal", "amount", "start_date", "end_date"]
 
-    # Need something as form validation
-    def clean(self):
-        cleaned_data = super().clean()
-        start_date = cleaned_data.get("start_date")
-        end_date = cleaned_data.get("end_date")
+    def __init__(self, github_username, *args, **kwargs):
+        self.github_username = github_username
+        super().__init__(*args, **kwargs)
 
+    def validate_dates(self, start_date, end_date):
         if start_date and end_date:
             if end_date < start_date:
                 raise ValidationError(
@@ -36,5 +36,22 @@ class GoalForm(ModelForm):
                         "end_date": "End date cannot be in the past",
                     }
                 )
+
+    def validate_repo(self, github_username, repo):
+        url = f"https://github.com/{github_username}/{repo}"
+        if "message" in get_response_from_url(url):
+            raise ValidationError(
+                {"repo": "This Github repository could not be found."}
+            )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        start_date = cleaned_data.get("start_date")
+        end_date = cleaned_data.get("end_date")
+        repo = cleaned_data.get("repo")
+
+        self.validate_dates(start_date, end_date)
+        self.validate_repo(self.github_username, repo)
 
         return cleaned_data

--- a/motivator/templates/motivator/goal_detail.html
+++ b/motivator/templates/motivator/goal_detail.html
@@ -12,6 +12,7 @@
                 <th scope="col">Amount</th>
                 <th scope="col">Start Date</th>
                 <th scope="col">Deadline</th>
+                <th scope="col">Commit Count</th>
             </tr>
         </thead>
         <tbody>
@@ -24,6 +25,7 @@
                 <td>{{ goal.amount }}</td>
                 <td>{{ goal.start_date }}</td>
                 <td>{{ goal.end_date }}</td>
+                <td>{{ goal.commit_count }}</td>
             </tr>
             {% endif %}
         </tbody>

--- a/motivator/templates/motivator/goal_detail.html
+++ b/motivator/templates/motivator/goal_detail.html
@@ -25,7 +25,7 @@
                 <td>{{ goal.amount }}</td>
                 <td>{{ goal.start_date }}</td>
                 <td>{{ goal.end_date }}</td>
-                <td>{{ goal.commit_count }}</td>
+                <td>{{ commit_count }}</td>
             </tr>
             {% endif %}
         </tbody>

--- a/motivator/templates/motivator/goal_list.html
+++ b/motivator/templates/motivator/goal_list.html
@@ -21,7 +21,7 @@
             <tr>
                 <th scope="row"><a href="{% url 'goal-detail' goal.goal.pk %}">{{ goal.goal.pk }}</a></th>
                 <td><a href="https://github.com/{{ goal.goal.github_username }}/{{ goal.goal.repo}}/"
-                        target="_blank">{{ goal.repo }}<a></td>
+                        target="_blank">{{ goal.goal.repo }}<a></td>
                 <td>{{ goal.goal.commit_goal }}</td>
                 <td>{{ goal.goal.amount }}</td>
                 <td>{{ goal.goal.start_date }}</td>

--- a/motivator/templates/motivator/goal_list.html
+++ b/motivator/templates/motivator/goal_list.html
@@ -12,19 +12,21 @@
                 <th scope="col">Amount</th>
                 <th scope="col">Start Date</th>
                 <th scope="col">Deadline</th>
+                <th scope="col">Commit Count</th>
             </tr>
         </thead>
         <tbody>
             {% if goals %}
-            {% for goal in goals %}
+            {% for goal in commit_goals %}
             <tr>
-                <th scope="row"><a href="{% url 'goal-detail' goal.pk %}">{{ goal.pk }}</a></th>
-                <td><a href="https://github.com/{{ goal.github_username }}/{{ goal.repo}}/"
+                <th scope="row"><a href="{% url 'goal-detail' goal.goal.pk %}">{{ goal.goal.pk }}</a></th>
+                <td><a href="https://github.com/{{ goal.goal.github_username }}/{{ goal.goal.repo}}/"
                         target="_blank">{{ goal.repo }}<a></td>
-                <td>{{ goal.commit_goal }}</td>
-                <td>{{ goal.amount }}</td>
-                <td>{{ goal.start_date }}</td>
-                <td>{{ goal.end_date }}</td>
+                <td>{{ goal.goal.commit_goal }}</td>
+                <td>{{ goal.goal.amount }}</td>
+                <td>{{ goal.goal.start_date }}</td>
+                <td>{{ goal.goal.end_date }}</td>
+                <td>{{ goal.count }}</td>
             </tr>
             {% endfor %}
             {% endif %}

--- a/motivator/utils.py
+++ b/motivator/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for the the GithubMotivator App"""
+import requests
+from requests.adapters import HTTPAdapter, Retry
+from requests.exceptions import (
+    HTTPError,
+    RequestException,
+    Timeout,
+    TooManyRedirects,
+)
+
+
+def get_response_from_url(url: str) -> dict[str, str] or requests.Response:
+    """Making a request to an url to get the response"""
+    retry_strategy = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["HEAD", "GET", "OPTIONS"],
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
+    with requests.Session() as http:
+        http.mount("https://", adapter)
+        http.mount("http://", adapter)
+
+        try:
+            response = http.get(url)
+            response.raise_for_status()
+        except Timeout:
+            print("Retry?")
+            return {"message": "Timeout"}
+        except HTTPError:
+            return {"message": "HTTPError"}
+        except TooManyRedirects:
+            return {"message": "TooManyRedirects"}
+        except RequestException:
+            return {"message": "RequestException"}
+
+    return response

--- a/motivator/utils.py
+++ b/motivator/utils.py
@@ -1,4 +1,6 @@
 """Utility functions for the the GithubMotivator App"""
+from typing import Union
+
 import requests
 from requests.adapters import HTTPAdapter, Retry
 from requests.exceptions import (
@@ -9,7 +11,9 @@ from requests.exceptions import (
 )
 
 
-def get_response_from_url(url: str) -> dict[str, str] or requests.Response:
+def get_response_from_url(
+    url: str,
+) -> Union[dict[str, str], requests.Response]:
     """Making a request to an url to get the response"""
     retry_strategy = Retry(
         total=3,

--- a/motivator/utils.py
+++ b/motivator/utils.py
@@ -3,12 +3,7 @@ from typing import Union
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
-from requests.exceptions import (
-    HTTPError,
-    RequestException,
-    Timeout,
-    TooManyRedirects,
-)
+from requests.exceptions import HTTPError, RequestException, Timeout, TooManyRedirects
 
 
 def get_response_from_url(
@@ -31,7 +26,6 @@ def get_response_from_url(
             response = http.get(url)
             response.raise_for_status()
         except Timeout:
-            print("Retry?")
             return {"message": "Timeout"}
         except HTTPError:
             return {"message": "HTTPError"}

--- a/motivator/utils.py
+++ b/motivator/utils.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError, RequestException, Timeout, TooManyRed
 
 
 def get_response_from_url(
-    url: str,
+    url: str, headers: dict[str, str] = {}
 ) -> Union[dict[str, str], requests.Response]:
     """Making a request to an url to get the response"""
     retry_strategy = Retry(
@@ -23,7 +23,7 @@ def get_response_from_url(
         http.mount("http://", adapter)
 
         try:
-            response = http.get(url)
+            response = http.get(url, headers=headers)
             response.raise_for_status()
         except Timeout:
             return {"message": "Timeout"}

--- a/motivator/utils_motivator.py
+++ b/motivator/utils_motivator.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.utils import timezone
+from pytz import UTC
 
 from .models import Goal
 from .utils import get_response_from_url
@@ -9,9 +10,8 @@ from .utils import get_response_from_url
 
 def parse_github_datetime(event_datetime: str) -> datetime:
     """Parse the Github UTC time to Europe/Amsterdam Timezone object"""
-    date_time = event_datetime[:-1].replace("T", " ")
-    github_utc_time = timezone.make_aware(datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S"))
-    return github_utc_time + timezone.timedelta(hours=2)
+    utc_time = timezone.make_aware(datetime.fromisoformat(event_datetime[:-1]), timezone=UTC)
+    return utc_time.astimezone()
 
 
 def count_commits(goal: Goal) -> int:

--- a/motivator/utils_motivator.py
+++ b/motivator/utils_motivator.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.conf import settings
 from django.utils import timezone
 
 from .models import Goal
@@ -7,15 +8,10 @@ from .utils import get_response_from_url
 
 
 def parse_github_datetime(event_datetime: str) -> datetime:
-    """Parse the created_at field from github api into datetime object"""
+    """Parse the Github UTC time to Europe/Amsterdam Timezone object"""
     date_time = event_datetime[:-1].replace("T", " ")
-
-    github_time = timezone.make_aware(
-        datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S")
-    )
-    # github_time_correction = timezone.timedelta(hours=2)
-    corrected_github_time = github_time + timezone.timedelta(hours=2)
-    return corrected_github_time
+    github_utc_time = timezone.make_aware(datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S"))
+    return github_utc_time + timezone.timedelta(hours=2)
 
 
 def count_commits(goal: Goal) -> int:
@@ -23,8 +19,9 @@ def count_commits(goal: Goal) -> int:
     count = 0
     base_url = "https://api.github.com/repos/"
     url = f"{base_url}{goal.github_username}/{goal.repo}/events"
+    headers = {"Time-Zone": settings.TIME_ZONE}
 
-    data = get_response_from_url(url)
+    data = get_response_from_url(url, headers)
 
     if "message" in data:
         # Think about specific error message for this situation?
@@ -32,14 +29,14 @@ def count_commits(goal: Goal) -> int:
         return "Error!"
 
     for event in data.json():
+        print(event["created_at"])
         event_datetime = parse_github_datetime(event["created_at"])
         if goal.start_date < event_datetime < goal.end_date:
             if "commits" in event["payload"]:
                 for commit in event["payload"]["commits"]:
                     count += 1
         else:
-            # Github API seems to sort the data from most recent to older
-            # Therefore, we can stop iterating once a data is outside the scope
+            # Github API orders the data from recent to older
             return count
 
     return count

--- a/motivator/utils_motivator.py
+++ b/motivator/utils_motivator.py
@@ -13,9 +13,9 @@ def parse_github_datetime(event_datetime: str) -> datetime:
     github_time = timezone.make_aware(
         datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S")
     )
-    github_time_correction = timezone.timedelta(hours=2)
-
-    return github_time + github_time_correction
+    # github_time_correction = timezone.timedelta(hours=2)
+    corrected_github_time = github_time + timezone.timedelta(hours=2)
+    return corrected_github_time
 
 
 def count_commits(goal: Goal) -> int:

--- a/motivator/utils_motivator.py
+++ b/motivator/utils_motivator.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from .models import Goal
+from .utils import get_response_from_url
+
+
+def parse_github_datetime(event_datetime: str) -> datetime:
+    """Parse the created_at field from github api into datetime object"""
+    date_time = event_datetime[:-1].replace("T", " ")
+
+    return datetime.strptime(date_time, "%Y-%m-%d %H:%M:%S")
+
+
+def count_commits(goal: Goal) -> int:
+    """Counts the amount commits for the provided Goal that have been made"""
+    count = 0
+    base_url = "https://api.github.com/repos/"
+    url = f"{base_url}{goal.github_username}/{goal.repo}/events"
+
+    data = get_response_from_url(url)
+
+    if "message" in data:
+        print("Error!")
+        return count
+
+    for event in data.json():
+        event_datetime = parse_github_datetime(event["created_at"])
+
+        if goal.start_date < event_datetime < goal.end_date:
+            if "commits" in event["payload"]:
+                for commit in event["payload"]["commits"]:
+                    count += 1
+        else:
+            # Github API seems to sort the data from most recent to older
+            # Therefore, we can stop iterating once a data is outside the scope
+            return count
+
+    return count

--- a/motivator/validators.py
+++ b/motivator/validators.py
@@ -13,3 +13,13 @@ def date_validator_min(value):
         raise ValidationError("Date cannot be in the past")
     else:
         return value
+
+
+# def validator_url_alive(value):
+#     url = f"https://github.com/{self.github_username}/{self.repo}"
+#     if "message" in get_response_from_url(url):
+#         raise ValidationError(
+#             {"repo": "This Github repository could not be found."}
+#         )
+#     else:
+#         return value

--- a/motivator/validators.py
+++ b/motivator/validators.py
@@ -13,13 +13,3 @@ def date_validator_min(value):
         raise ValidationError("Date cannot be in the past")
     else:
         return value
-
-
-# def validator_url_alive(value):
-#     url = f"https://github.com/{self.github_username}/{self.repo}"
-#     if "message" in get_response_from_url(url):
-#         raise ValidationError(
-#             {"repo": "This Github repository could not be found."}
-#         )
-#     else:
-#         return value

--- a/motivator/views.py
+++ b/motivator/views.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import render
@@ -7,31 +9,51 @@ from users.models import UserMotivator
 
 from .forms import GoalForm
 from .models import Goal
+from .utils_motivator import count_commits
 
 
 def index(request):
+    """View for the homepage of the website"""
     return render(request, "motivator/index.html", {"title": "Home"})
 
 
 class ListGoal(LoginRequiredMixin, ListView):
+    """Overview of all the Goals"""
+
     model = Goal
     context_object_name = "goals"
 
     def get_queryset(self):
         return Goal.objects.filter(user=self.request.user)
 
+    # def get_context_data(self, **kwargs):
+    #     pass
+    #     # context = super().get_context_data(**kwargs)
+    #     # context[""] =
+    #     # return context
+
 
 class DetailGoal(LoginRequiredMixin, DetailView):
+    """View where the user can see the details of a specified Goal"""
+
     model = Goal
     context_object_name = "goal"
 
+    # def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+    #     context = super().get_context_data(**kwargs)
+    #     context["commit_count"] = count_commits(context)
+    #     return context
+
 
 class CreateGoal(LoginRequiredMixin, SuccessMessageMixin, CreateView):
+    """View where the user can create a new Goal"""
+
     model = Goal
     form_class = GoalForm
     success_message = "Your goal has been set"
 
     def get_form_kwargs(self):
+        """Get the extra parameters for the form to validate the repo url"""
         self.github_username = (
             UserMotivator.objects.filter(user=self.request.user)
             .first()
@@ -45,6 +67,7 @@ class CreateGoal(LoginRequiredMixin, SuccessMessageMixin, CreateView):
         return reverse("goal-list")
 
     def form_valid(self, form):
+        """Adds the extra fields to save in the Model"""
         form.instance.user = self.request.user
         form.instance.github_username = self.github_username
         return super(CreateGoal, self).form_valid(form)

--- a/motivator/views.py
+++ b/motivator/views.py
@@ -7,9 +7,9 @@ from django.urls import reverse
 from django.views.generic import CreateView, DetailView, ListView
 from users.models import UserMotivator
 
-from .forms import GoalForm
-from .models import Goal
-from .utils_motivator import count_commits
+from motivator.forms import GoalForm
+from motivator.models import Goal
+from motivator.utils_motivator import count_commits
 
 
 def index(request):
@@ -57,9 +57,7 @@ class CreateGoal(LoginRequiredMixin, SuccessMessageMixin, CreateView):
     def get_form_kwargs(self):
         """Get the extra parameters for the form to validate the repo url"""
         self.github_username = (
-            UserMotivator.objects.filter(user=self.request.user)
-            .first()
-            .github_username
+            UserMotivator.objects.filter(user=self.request.user).first().github_username
         )
         kwargs = super(CreateGoal, self).get_form_kwargs()
         kwargs["github_username"] = self.github_username

--- a/motivator/views.py
+++ b/motivator/views.py
@@ -26,11 +26,13 @@ class ListGoal(LoginRequiredMixin, ListView):
     def get_queryset(self):
         return Goal.objects.filter(user=self.request.user)
 
-    # def get_context_data(self, **kwargs):
-    #     pass
-    #     # context = super().get_context_data(**kwargs)
-    #     # context[""] =
-    #     # return context
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["commit_goals"] = []
+        for goal in context["goals"]:
+            commit_goal = {"goal": goal, "count": count_commits(goal)}
+            context["commit_goals"].append(commit_goal)
+        return context
 
 
 class DetailGoal(LoginRequiredMixin, DetailView):
@@ -39,10 +41,10 @@ class DetailGoal(LoginRequiredMixin, DetailView):
     model = Goal
     context_object_name = "goal"
 
-    # def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-    #     context = super().get_context_data(**kwargs)
-    #     context["commit_count"] = count_commits(context)
-    #     return context
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["commit_count"] = count_commits(context["goal"])
+        return context
 
 
 class CreateGoal(LoginRequiredMixin, SuccessMessageMixin, CreateView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ astroid==2.11.1
 attrs==21.4.0
 autopep8==1.6.0
 black==22.3.0
+certifi==2021.10.8
+charset-normalizer==2.0.12
 click==8.1.2
 coverage==6.3.2
 dill==0.3.4
@@ -13,11 +15,13 @@ django-environ==0.8.1
 dnspython==2.2.1
 Faker==12.0.1
 flake8==4.0.1
+idna==3.3
 iniconfig==1.1.1
 isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.6.1
 mixer==7.2.2
+mypy==0.950
 mypy-extensions==0.4.3
 packaging==21.3
 pathspec==0.9.0
@@ -34,9 +38,12 @@ pytest-cov==3.0.0
 pytest-django==4.5.2
 python-dateutil==2.8.2
 pytz==2022.1
+requests==2.27.1
 six==1.16.0
 sqlparse==0.2.4
 toml==0.10.2
 tomli==2.0.1
+typing_extensions==4.2.0
+urllib3==1.26.9
 uuid==1.30
 wrapt==1.14.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def registered_user(client, db):
         "email": "test@test.com",
         "password1": "PasswordofTestUser",
         "password2": "PasswordofTestUser",
-        "github_username": "testhub",
+        "github_username": "abczzz13",
     }
 
     client.post("/register/", user)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,7 @@ def user(db):
 def goal(user):
     start_date = timezone.now() + timezone.timedelta(minutes=1)
     end_date = timezone.now() + timezone.timedelta(days=1)
-    motivator_goal = mixer.blend(
-        Goal, start_date=start_date, end_date=end_date
-    )
+    motivator_goal = mixer.blend(Goal, start_date=start_date, end_date=end_date)
     motivator_goal.user = user.user
     return motivator_goal
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,18 @@
 import pytest
 from django.utils import timezone
 from mixer.backend.django import mixer
+
 from motivator.models import Goal
 from users.models import User, UserMotivator
 
 
 @pytest.fixture()
 def user(db):
-    motivator = mixer.blend(UserMotivator)
+    motivator = mixer.blend(UserMotivator, github_username="abczzz13")
     test_user = mixer.blend(User, username="Test User")
     motivator.user = test_user
+    motivator.save()
+    test_user.save()
     return motivator
 
 

--- a/tests/motivator/functional/test_new_goal.py
+++ b/tests/motivator/functional/test_new_goal.py
@@ -38,7 +38,7 @@ def test_create_goal_unauthenticated(client):
     "repo, commit_goal, amount, start_date, end_date, status_code",
     [
         (
-            "testrepo",
+            "GithubMotivator",
             10,
             10,
             timezone.now(),
@@ -54,7 +54,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo",
+            "GithubMotivator",
             "",
             10,
             timezone.now(),
@@ -62,7 +62,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo",
+            "GithubMotivator",
             10,
             "",
             timezone.now(),
@@ -70,16 +70,16 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo",
+            "GithubMotivator",
             10,
             10,
             "",
             timezone.now() + timezone.timedelta(days=7),
             200,
         ),
-        ("testrepo", 10, 10, timezone.now(), "", 200),
+        ("GithubMotivator", 10, 10, timezone.now(), "", 200),
         (
-            "testrepo",
+            "tGithubMotivator",
             0,
             10,
             timezone.now(),
@@ -87,7 +87,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo",
+            "GithubMotivator",
             10,
             0,
             timezone.now(),
@@ -95,7 +95,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo1",
+            "GithubMotivator",
             10,
             10,
             timezone.now() - timezone.timedelta(days=7),
@@ -103,7 +103,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo2",
+            "GithubMotivator",
             10,
             10,
             timezone.now() - timezone.timedelta(days=7),
@@ -111,7 +111,7 @@ def test_create_goal_unauthenticated(client):
             200,
         ),
         (
-            "testrepo3",
+            "GithubMotivator",
             10,
             10,
             timezone.now(),

--- a/tests/motivator/unit/test_motivator_forms.py
+++ b/tests/motivator/unit/test_motivator_forms.py
@@ -3,40 +3,45 @@ import pytest
 from django.utils import timezone
 from motivator.forms import GoalForm
 
+now = timezone.now()
+last_week = timezone.now() - timezone.timedelta(days=7)
+next_week = timezone.now() + timezone.timedelta(days=7)
+last_day = timezone.now() - timezone.timedelta(days=1)
+
 
 @pytest.mark.parametrize(
     "repo, commit_goal, amount, start_date, end_date, assertion",
     [
         (
-            "testrepo",
+            "GithubMotivator",
             10,
             10,
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             True,
         ),
         (
             "",
             10,
             10,
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             False,
         ),
         (
             "testrepo",
             "",
             10,
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             False,
         ),
         (
             "testrepo",
             10,
             "",
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             False,
         ),
         (
@@ -44,48 +49,48 @@ from motivator.forms import GoalForm
             10,
             10,
             "",
-            timezone.now() + timezone.timedelta(days=7),
+            next_week,
             False,
         ),
-        ("testrepo", 10, 10, timezone.now(), "", False),
+        ("testrepo", 10, 10, now, "", False),
         (
             "testrepo",
             0,
             10,
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             False,
         ),
         (
             "testrepo",
             10,
             0,
-            timezone.now(),
-            timezone.now() + timezone.timedelta(days=7),
+            now,
+            next_week,
             False,
         ),
         (
             "testrepo",
             10,
             10,
-            timezone.now() - timezone.timedelta(days=7),
-            timezone.now() + timezone.timedelta(days=7),
+            last_week,
+            next_week,
             False,
         ),
         (
             "testrepo",
             10,
             10,
-            timezone.now() - timezone.timedelta(days=7),
-            timezone.now() - timezone.timedelta(days=1),
+            last_week,
+            last_day,
             False,
         ),
         (
             "testrepo",
             10,
             10,
-            timezone.now(),
-            timezone.now() - timezone.timedelta(days=1),
+            now,
+            last_day,
             False,
         ),
     ],
@@ -103,7 +108,5 @@ def test_goal_form(repo, commit_goal, amount, start_date, end_date, assertion):
         "start_date": start_date,
         "end_date": end_date,
     }
-
-    form = GoalForm(data)
-
+    form = GoalForm("abczzz13", data)
     assert form.is_valid() == assertion

--- a/tests/motivator/unit/test_motivator_views.py
+++ b/tests/motivator/unit/test_motivator_views.py
@@ -58,6 +58,7 @@ def test_motivator_goals_create(rf, user):
     path = reverse("goal-create")
     request = rf.get(path)
     request.user = user.user
+    print(dir(user.user.usermotivator))
 
     response = CreateGoal.as_view()(request)
 

--- a/tests/motivator/unit/test_motivator_views.py
+++ b/tests/motivator/unit/test_motivator_views.py
@@ -38,9 +38,7 @@ def test_motivator_goals_detail(rf, goal):
     WHEN a GET request is made to 'goal-detail' view function
     THEN check that the response is valid
     """
-    print(goal.id)
     path = reverse("goal-detail", args=[goal.id])
-    print(path)
     request = rf.get(path)
     request.user = goal.user
 
@@ -58,7 +56,6 @@ def test_motivator_goals_create(rf, user):
     path = reverse("goal-create")
     request = rf.get(path)
     request.user = user.user
-    print(dir(user.user.usermotivator))
 
     response = CreateGoal.as_view()(request)
 

--- a/tests/motivator/unit/test_utils_count_commits.py
+++ b/tests/motivator/unit/test_utils_count_commits.py
@@ -8,35 +8,29 @@ from motivator.utils_motivator import count_commits
 def test_utils_count_commits_valid(goal: Goal):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
-
-    >>> This test currently only works if the commits on this project is active enough
+    WHEN the commits of an active Github repo is counted
+    THEN the count of this repo is more than 0
     """
+    # This test currently only works if the commits on this project is active enough
     goal.github_username = "abczzz13"
     goal.repo = "GithubMotivator"
 
     goal.start_date = timezone.now() - timezone.timedelta(days=100)
     goal.end_date = timezone.now()
 
-    count = count_commits(goal)
-
-    assert count > 0
+    assert count_commits(goal) > 0
 
 
 def test_utils_count_commits_invalid_date(goal: Goal):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
-
-    >>> This test currently only works if the commits on this project is active enough
+    WHEN the commits are counted before the repo was active
+    THEN no commits are counted
     """
+    # This test currently only works if the commits on this project is active enough
     goal.github_username = "abczzz13"
     goal.repo = "GithubMotivator"
     goal.start_date = timezone.make_aware(datetime(year=2021, month=1, day=1))
     goal.end_date = timezone.make_aware(datetime(year=2021, month=1, day=31))
 
-    count = count_commits(goal)
-
-    assert count == 0
+    assert count_commits(goal) == 0

--- a/tests/motivator/unit/test_utils_count_commits.py
+++ b/tests/motivator/unit/test_utils_count_commits.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
-import pytest
+from django.utils import timezone
 from motivator.models import Goal
 from motivator.utils_motivator import count_commits
 
@@ -15,9 +15,28 @@ def test_utils_count_commits_valid(goal: Goal):
     """
     goal.github_username = "abczzz13"
     goal.repo = "GithubMotivator"
-    goal.start_date = datetime.now() - timedelta(days=21)
-    goal.end_date = datetime.now()
+
+    goal.start_date = timezone.now() - timezone.timedelta(days=100)
+    goal.end_date = timezone.now()
 
     count = count_commits(goal)
 
     assert count > 0
+
+
+def test_utils_count_commits_invalid_date(goal: Goal):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+
+    >>> This test currently only works if the commits on this project is active enough
+    """
+    goal.github_username = "abczzz13"
+    goal.repo = "GithubMotivator"
+    goal.start_date = timezone.make_aware(datetime(year=2021, month=1, day=1))
+    goal.end_date = timezone.make_aware(datetime(year=2021, month=1, day=31))
+
+    count = count_commits(goal)
+
+    assert count == 0

--- a/tests/motivator/unit/test_utils_count_commits.py
+++ b/tests/motivator/unit/test_utils_count_commits.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+
+import pytest
+from motivator.models import Goal
+from motivator.utils_motivator import count_commits
+
+
+def test_utils_count_commits_valid(goal: Goal):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+
+    >>> This test currently only works if the commits on this project is active enough
+    """
+    goal.github_username = "abczzz13"
+    goal.repo = "GithubMotivator"
+    goal.start_date = datetime.now() - timedelta(days=21)
+    goal.end_date = datetime.now()
+
+    count = count_commits(goal)
+
+    assert count > 0

--- a/tests/motivator/unit/test_utils_parse_datetime.py
+++ b/tests/motivator/unit/test_utils_parse_datetime.py
@@ -7,16 +7,14 @@ from motivator.utils_motivator import parse_github_datetime
     "event_datetime, result",
     [
         ("2022-04-25T12:09:04Z", timezone.datetime(2022, 4, 25, 14, 9, 4)),
-        ("2022-03-25T09:58:46Z", timezone.datetime(2022, 3, 25, 11, 58, 46)),
+        ("2022-03-25T09:58:46Z", timezone.datetime(2022, 3, 25, 10, 58, 46)),
     ],
 )
 def test_goal_model_validation_error(event_datetime, result):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
-    ! please note the time correction from Github time +2 hours
+    WHEN a UTC time from Github is parsed
+    THEN the correct Timezone Europe/Amsterdam time is returned
     """
     output = parse_github_datetime(event_datetime)
-
     assert output == timezone.make_aware(result)

--- a/tests/motivator/unit/test_utils_parse_datetime.py
+++ b/tests/motivator/unit/test_utils_parse_datetime.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+import pytest
+from motivator.utils_motivator import parse_github_datetime
+
+
+@pytest.mark.parametrize(
+    "event_datetime, result",
+    [
+        ("2022-04-25T12:09:04Z", datetime(2022, 4, 25, 12, 9, 4)),
+        ("2022-03-25T09:58:46Z", datetime(2022, 3, 25, 9, 58, 46)),
+    ],
+)
+def test_goal_model_validation_error(event_datetime, result):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+    """
+
+    assert parse_github_datetime(event_datetime) == result

--- a/tests/motivator/unit/test_utils_parse_datetime.py
+++ b/tests/motivator/unit/test_utils_parse_datetime.py
@@ -1,14 +1,13 @@
-from datetime import datetime
-
 import pytest
+from django.utils import timezone
 from motivator.utils_motivator import parse_github_datetime
 
 
 @pytest.mark.parametrize(
     "event_datetime, result",
     [
-        ("2022-04-25T12:09:04Z", datetime(2022, 4, 25, 12, 9, 4)),
-        ("2022-03-25T09:58:46Z", datetime(2022, 3, 25, 9, 58, 46)),
+        ("2022-04-25T12:09:04Z", timezone.datetime(2022, 4, 25, 14, 9, 4)),
+        ("2022-03-25T09:58:46Z", timezone.datetime(2022, 3, 25, 11, 58, 46)),
     ],
 )
 def test_goal_model_validation_error(event_datetime, result):
@@ -16,6 +15,7 @@ def test_goal_model_validation_error(event_datetime, result):
     GIVEN a Django application configured for testing
     WHEN
     THEN
+    ! please note the time correction from Github time +2 hours
     """
-
-    assert parse_github_datetime(event_datetime) == result
+    output = parse_github_datetime(event_datetime)
+    assert output == timezone.make_aware(result)

--- a/tests/motivator/unit/test_utils_parse_datetime.py
+++ b/tests/motivator/unit/test_utils_parse_datetime.py
@@ -18,4 +18,5 @@ def test_goal_model_validation_error(event_datetime, result):
     ! please note the time correction from Github time +2 hours
     """
     output = parse_github_datetime(event_datetime)
+
     assert output == timezone.make_aware(result)

--- a/tests/motivator/unit/test_utils_retrieve_api_data.py
+++ b/tests/motivator/unit/test_utils_retrieve_api_data.py
@@ -1,15 +1,12 @@
 import pytest
 from motivator.utils import get_response_from_url
 
-# url = f"https://api.github.com/repos/{goal['github_user']}/{goal['repo']}/events"
-# "https://api.github.com/repos/abczzz13/GithubMotivator/events"
-
 
 def test_get_response_from_url_valid_data():
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
+    WHEN an external call is made to the Github API with a valid repo
+    THEN check that there is no error message
     """
     url = "https://api.github.com/repos/abczzz13/GithubMotivator/events"
     response = get_response_from_url(url)
@@ -39,8 +36,8 @@ def test_get_response_from_url_valid_data():
 def test_get_response_from_url_invalid_data(url: str, result: str):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
+    WHEN an external call is made to the Github API with a invalid repo
+    THEN check that there is an error message
     """
     response = get_response_from_url(url)
     assert response["message"] == result
@@ -62,8 +59,8 @@ def test_get_response_from_url_invalid_data(url: str, result: str):
 def test_utils_get_response_from_url_valid_status_code(url: str, result: int):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
+    WHEN an external call is made to the Github API with a valid url
+    THEN a status code of 200 is returned
     """
     response = get_response_from_url(url)
     assert response.status_code == result
@@ -78,13 +75,11 @@ def test_utils_get_response_from_url_valid_status_code(url: str, result: int):
         ),
     ],
 )
-def test_utils_get_response_from_url_invalid_status_code(
-    url: str, result: dict[str, str]
-):
+def test_utils_get_response_from_url_invalid_status_code(url: str, result: dict[str, str]):
     """
     GIVEN a Django application configured for testing
-    WHEN
-    THEN
+    WHEN an external call is made to the Github API with a invalid repo
+    THEN the appropriate error is raised
     """
     response = get_response_from_url(url)
     assert response == result

--- a/tests/motivator/unit/test_utils_retrieve_api_data.py
+++ b/tests/motivator/unit/test_utils_retrieve_api_data.py
@@ -1,0 +1,90 @@
+import pytest
+from motivator.utils import get_response_from_url
+
+# url = f"https://api.github.com/repos/{goal['github_user']}/{goal['repo']}/events"
+# "https://api.github.com/repos/abczzz13/GithubMotivator/events"
+
+
+def test_get_response_from_url_valid_data():
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+    """
+    url = "https://api.github.com/repos/abczzz13/GithubMotivator/events"
+    response = get_response_from_url(url)
+
+    assert "message" not in response
+
+
+@pytest.mark.parametrize(
+    "url, result",
+    [
+        (
+            "https://api.github.com/repos/abczzz13/GithubMotivator/eventsz",
+            "HTTPError",
+        ),
+        ("https://test.tdejong.io/", "RequestException"),
+        ("", "RequestException"),
+        (
+            "https://api.github.com/repos/abczzzx13/GithubMotivator/events",
+            "HTTPError",
+        ),
+        (
+            "https://api.github.com/repos/abczzz13/GithubMotivatorz/events",
+            "HTTPError",
+        ),
+    ],
+)
+def test_get_response_from_url_invalid_data(url: str, result: str):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+    """
+    response = get_response_from_url(url)
+    assert response["message"] == result
+
+
+@pytest.mark.parametrize(
+    "url, result",
+    [
+        (
+            "https://github.com/abczzz13",
+            200,
+        ),
+        (
+            "https://github.com/abczzz13/GithubMotivator",
+            200,
+        ),
+    ],
+)
+def test_utils_get_response_from_url_valid_status_code(url: str, result: int):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+    """
+    response = get_response_from_url(url)
+    assert response.status_code == result
+
+
+@pytest.mark.parametrize(
+    "url, result",
+    [
+        (
+            "https://github.com/abczzz13/GithubMotivatorz",
+            {"message": "HTTPError"},
+        ),
+    ],
+)
+def test_utils_get_response_from_url_invalid_status_code(
+    url: str, result: dict[str, str]
+):
+    """
+    GIVEN a Django application configured for testing
+    WHEN
+    THEN
+    """
+    response = get_response_from_url(url)
+    assert response == result


### PR DESCRIPTION
## What?
Added a commit counter to count the commits of the specified Github repository within the selected period of the goal.

## Why?
With the commit counter we can check the user progress on the goal.

## How?
I have created a function get_response_from_url which makes a get request to a specified url and returns the json response with the requests libary, which also includes retries. This function gets called by the specific function count_commits which creates the url and processes the response by counting the commits.

The function get_response_from_url has also been used in the Goal form to validate if the specified repository exists on Github for the current user. (fixing issues #3)

Additionally, a function parse_github_datetime has been created to parse the Github UTC time to the current Django Timezone.

## Testing?
Currently, the tests are based on making external API calls, which leads to two problems.

1. In staging / production it is not always possible to have external access.
2. Tests might sometimes fail due to different HTTPErrors

A solution for this might be to use monkeypatch to patch the external API calls to return a expected result without making the external API call. An issue #8 for this has been created.

Tests have been included for the new features and all tests pass.

## Anything else?
Need to think about error handling, where to raise errors and how to handle them. At this moment, when an error arises during counting the commits this will also be shown on the frontend to the user.

Additionally, there is currently no check who has made the commit. It only measures the commit progress on repository. Something to look into.

To finalize this feature we will also need periodic tasks to count the commits to see if the goals have been completed and take the appropriate action.